### PR TITLE
cg_fovscale and cg_fov changes

### DIFF
--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -43,11 +43,11 @@ namespace
 		return dvar_register_int_hook.invoke<game::dvar_t*>(dvarName, value, min, max, flags, description);
 	}
 
-	game::dvar_t* register_dvar_float(const char* name, float value, float min, float max, unsigned int flags,
+	game::dvar_t* register_fovscale_stub(const char* name, float /*value*/, float /*min*/, float /*max*/, unsigned int /*flags*/,
 		const char* desc)
 	{
 		// changed max value from 2.0f -> 5.0f and min value from 0.5f -> 0.1f
-		return game::Dvar_RegisterFloat("cg_fovScale", 1.0f, 0.1f, 5.0f, 0x1, "The field of view multiplier");
+		return game::Dvar_RegisterFloat(name, 1.0f, 0.1f, 5.0f, 0x1, desc);
 	}
 }
 
@@ -151,7 +151,8 @@ public:
 		// Enable DLC items, extra loadouts and map selection in extinction
 		dvar_register_int_hook.create(0x1404EE270, &dvar_register_int);
 
-		utils::hook::call(0x140272777, register_dvar_float); // Register cg_fovscale with new params
+		// Register cg_fovscale with new params
+		utils::hook::call(0x140272777, register_fovscale_stub);
 	}
 
 	void patch_sp() const

--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -42,6 +42,13 @@ namespace
 
 		return dvar_register_int_hook.invoke<game::dvar_t*>(dvarName, value, min, max, flags, description);
 	}
+
+	game::dvar_t* register_dvar_float(const char* name, float value, float min, float max, unsigned int flags,
+		const char* desc)
+	{
+		// changed max value from 2.0f -> 5.0f and min value from 0.5f -> 0.1f
+		return game::Dvar_RegisterFloat("cg_fovScale", 1.0f, 0.1f, 5.0f, 0x1, "The field of view multiplier");
+	}
 }
 
 class patches final : public module
@@ -80,8 +87,8 @@ public:
 			game::Dvar_RegisterInt("com_maxfps", 85, 0, 1000, 0x1, "Cap frames per second");
 		}
 
-		// changed max value from 80.0f -> 120.f
-		game::Dvar_RegisterFloat("cg_fov", 65.0f, 65.0f, 120.0f, 0x1, "The field of view angle in degrees");
+		// changed max value from 80.0f -> 120.f and min value from 65.0f -> 1.0f
+		game::Dvar_RegisterFloat("cg_fov", 65.0f, 1.0f, 120.0f, 0x1, "The field of view angle in degrees");
 
 		command::add("dvarDump", []()
 		{
@@ -143,6 +150,8 @@ public:
 
 		// Enable DLC items, extra loadouts and map selection in extinction
 		dvar_register_int_hook.create(0x1404EE270, &dvar_register_int);
+
+		utils::hook::call(0x140272777, register_dvar_float); // Register cg_fovscale with new params
 	}
 
 	void patch_sp() const


### PR DESCRIPTION
I decreased the minimum value of the cg_fov from 65.0 to 1.0, increased the maximum value of cg_fovscale from 2.0 to 5.0, and decreased the minimum value of cg_fovscale from 0.5 to 0.1. These changes helps players pick the right combination of cg_fov and cg_fovscale to make their ADS and hip-fire sensitivities and FOVs equal. For example, I prefer to use a cg_fov of 55 and a cg_fovscale of 1.9, allowing me to use the same FOV as MW 2019 at 120 FOV and a 1:1 ADS and hip-fire sensitivity. 