### PR TITLE
Implement sv_cheats

### DIFF
--- a/src/client/game/game.cpp
+++ b/src/client/game/game.cpp
@@ -30,6 +30,8 @@ namespace game
 	Dvar_RegisterString_t Dvar_RegisterString;
 	Dvar_RegisterVec2_t Dvar_RegisterVec2;
 	Dvar_RegisterVec4_t Dvar_RegisterVec4;
+	Dvar_Reset_t Dvar_Reset;
+	Dvar_SetBool_t Dvar_SetBool;
 	Dvar_Sort_t Dvar_Sort;
 	Dvar_ValueToString_t Dvar_ValueToString;
 
@@ -180,6 +182,8 @@ namespace game
 			Dvar_RegisterString = Dvar_RegisterString_t(SELECT_VALUE(0x14042B7A0, 0x1404EE660));
 			Dvar_RegisterVec2 = Dvar_RegisterVec2_t(SELECT_VALUE(0x14042B880, 0x1404EE740));
 			Dvar_RegisterVec4 = Dvar_RegisterVec4_t(SELECT_VALUE(0x14042BC10, 0x1404EEA50));
+			Dvar_Reset = Dvar_Reset_t(SELECT_VALUE(0x14042C150, 0x1404EF020));
+			Dvar_SetBool = Dvar_SetBool_t(SELECT_VALUE(0x14042C370, 0x1404EF1A0));
 			Dvar_Sort = Dvar_Sort_t(SELECT_VALUE(0x14042DEF0, 0x1404F1210));
 			Dvar_ValueToString = Dvar_ValueToString_t(SELECT_VALUE(0x14042E710, 0x1404F1A30));
 

--- a/src/client/game/game.hpp
+++ b/src/client/game/game.hpp
@@ -76,6 +76,12 @@ namespace game
 	                                       float max, unsigned int flags, const char* description);
 	extern Dvar_RegisterVec4_t Dvar_RegisterVec4;
 
+	typedef void (*Dvar_Reset_t)(dvar_t* dvar, DvarSetSource source);
+	extern Dvar_Reset_t Dvar_Reset;
+
+	typedef void (*Dvar_SetBool_t)(dvar_t* dvar, bool value);
+	extern Dvar_SetBool_t Dvar_SetBool;
+
 	typedef void (*Dvar_Sort_t)();
 	extern Dvar_Sort_t Dvar_Sort;
 

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -559,6 +559,27 @@ namespace game
 		CA_ACTIVE = 0xA,
 	};
 
+	enum DvarSetSource : std::uint32_t
+	{
+		DVAR_SOURCE_INTERNAL = 0x0,
+		DVAR_SOURCE_EXTERNAL = 0x1,
+		DVAR_SOURCE_SCRIPT = 0x2,
+		DVAR_SOURCE_UISCRIPT = 0x3,
+		DVAR_SOURCE_SERVERCMD = 0x4,
+		DVAR_SOURCE_NUM = 0x5,
+	};
+
+	enum DvarFlags : std::uint32_t
+	{
+		DVAR_FLAG_NONE = 0,
+		DVAR_FLAG_SAVED = 0x1,
+		DVAR_FLAG_LATCHED = 0x2,
+		DVAR_FLAG_CHEAT = 0x4,
+		DVAR_FLAG_REPLICATED = 0x8,
+		DVAR_FLAG_WRITE = 0x800,
+		DVAR_FLAG_READ = 0x2000,
+	};
+
 	enum dvar_type : std::int8_t
 	{
 		boolean = 0,

--- a/src/client/module/command.cpp
+++ b/src/client/module/command.cpp
@@ -168,10 +168,25 @@ namespace command
 		{
 			client_command_hook.create(0x1403929B0, &client_command);
 
+			add_sv("god", [&](const int client_num, params_sv&)
+			{
+				if (!game::Dvar_FindVar("sv_cheats")->current.enabled)
+				{
+					game::SV_GameSendServerCommand(client_num, 1, "f \"Cheats are not enabled on this server\"");
+					return;
+				}
+
+				game::mp::g_entities[client_num].flags ^= 1;
+				game::SV_GameSendServerCommand(client_num, 1,
+											   utils::string::va("f \"godmode %s\"",
+											   game::mp::g_entities[client_num].flags & 1 ? "^2on" : "^1off"));
+			});
+
 			add_sv("noclip", [&](const int client_num, params_sv&)
 			{
-				if (!game::SV_Loaded())
+				if (!game::Dvar_FindVar("sv_cheats")->current.enabled)
 				{
+					game::SV_GameSendServerCommand(client_num, 1, "f \"Cheats are not enabled on this server\"");
 					return;
 				}
 
@@ -185,8 +200,9 @@ namespace command
 
 			add_sv("ufo", [&](const int client_num, params_sv&)
 			{
-				if (!game::SV_Loaded())
+				if (!game::Dvar_FindVar("sv_cheats")->current.enabled)
 				{
+					game::SV_GameSendServerCommand(client_num, 1, "f \"Cheats are not enabled on this server\"");
 					return;
 				}
 
@@ -200,8 +216,9 @@ namespace command
 
 			add_sv("setviewpos", [&](const int client_num, params_sv& params)
 			{
-				if (!game::SV_Loaded())
+				if (!game::Dvar_FindVar("sv_cheats")->current.enabled)
 				{
+					game::SV_GameSendServerCommand(client_num, 1, "f \"Cheats are not enabled on this server\"");
 					return;
 				}
 
@@ -212,8 +229,9 @@ namespace command
 
 			add_sv("setviewang", [&](const int client_num, params_sv& params)
 			{
-				if (!game::SV_Loaded())
+				if (!game::Dvar_FindVar("sv_cheats")->current.enabled)
 				{
+					game::SV_GameSendServerCommand(client_num, 1, "f \"Cheats are not enabled on this server\"");
 					return;
 				}
 

--- a/src/client/module/dvar_cheats.cpp
+++ b/src/client/module/dvar_cheats.cpp
@@ -1,0 +1,125 @@
+#include <std_include.hpp>
+#include "loader/module_loader.hpp"
+#include "utils/hook.hpp"
+#include "game/game.hpp"
+
+#include "game_console.hpp"
+#include "scheduler.hpp"
+
+namespace dvar_cheats
+{
+	void apply_sv_cheats(game::dvar_t* dvar, game::DvarSetSource source, game::dvar_value* value)
+	{
+		if (dvar && dvar->name == "sv_cheats"s)
+		{
+			// if dedi, do not allow internal to change value so servers can allow cheats if they want to
+			if (game::environment::is_dedi() && source == game::DvarSetSource::DVAR_SOURCE_INTERNAL)
+			{
+				value->enabled = dvar->current.enabled;
+			}
+
+			// if sv_cheats was enabled and it changes to disabled, we need to reset all cheat dvars
+			else if (dvar->current.enabled && !value->enabled)
+			{
+				for (auto i = 0; i < *game::dvarCount; ++i)
+				{
+					const auto var = game::sortedDvars[i];
+					if (var && (var->flags & game::DvarFlags::DVAR_FLAG_CHEAT))
+					{
+						game::Dvar_Reset(var, game::DvarSetSource::DVAR_SOURCE_INTERNAL);
+					}
+				}
+			}
+		}
+	}
+
+	bool dvar_flag_checks(game::dvar_t* dvar, game::DvarSetSource source)
+	{
+		if ((dvar->flags & game::DvarFlags::DVAR_FLAG_WRITE))
+		{
+			game_console::print(1, "%s is write protected", dvar->name);
+			return false;
+		}
+
+		if ((dvar->flags & game::DvarFlags::DVAR_FLAG_READ))
+		{
+			game_console::print(1, "%s is read only", dvar->name);
+			return false;
+		}
+
+		const auto cl_ingame = game::Dvar_FindVar("cl_ingame");
+		const auto sv_running = game::Dvar_FindVar("sv_running");
+
+		if ((dvar->flags & game::DvarFlags::DVAR_FLAG_REPLICATED) && (cl_ingame && cl_ingame->current.enabled) && (sv_running && !sv_running->current.enabled))
+		{
+			game_console::print(1, "%s can only be changed by the server", dvar->name);
+			return false;
+		}
+
+		const auto sv_cheats = game::Dvar_FindVar("sv_cheats");
+
+		// only check cheat-protected values when the source is external (CoD4 does this too)
+		if (source == game::DvarSetSource::DVAR_SOURCE_EXTERNAL && (dvar->flags & game::DvarFlags::DVAR_FLAG_CHEAT) && (sv_cheats && !sv_cheats->current.enabled))
+		{
+			game_console::print(1, "%s is cheat protected", dvar->name);
+			return false;
+		}
+
+		// pass all the flag checks, allow dvar to be changed
+		return true;
+	}
+
+	const auto dvar_flag_checks_stub = utils::hook::assemble([](utils::hook::assembler& a)
+	{
+		const auto can_set_value = a.newLabel();
+		const auto zero_source = a.newLabel();
+
+		a.pushad64();
+		a.mov(r8, rdi);
+		a.mov(edx, esi);
+		a.mov(rcx, rbx);
+		a.call(apply_sv_cheats); //check if we are setting sv_cheats
+		a.popad64();
+		a.cmp(esi, 0);
+		a.jz(zero_source); //if the SetSource is 0 (INTERNAL) ignore flag checks
+
+		a.pushad64();
+		a.mov(edx, esi); //source
+		a.mov(rcx, rbx); //dvar
+		a.call(dvar_flag_checks); //don't allow read/write/cheat/replicated dvars to be changed unless host
+		a.cmp(al, 1);
+		a.jz(can_set_value);
+
+		// if we get here, we are non-zero source and CANNOT set values
+		a.popad64(); // if I do this before the jz it won't work. for some reason the popad64 is affecting the ZR flag
+		a.jmp(0x1404F0FC5);
+
+		// if we get here, we are non-zero source and CAN set values
+		a.bind(can_set_value);
+		a.popad64(); // if I do this before the jz it won't work. for some reason the popad64 is affecting the ZR flag
+		a.jmp(0x1404F0D2E);
+		
+		// if we get here, we are zero source and ignore flags
+		a.bind(zero_source);
+		a.jmp(0x1404F0D74);
+	});
+
+	class module final : public module_interface
+	{
+	public:
+		void post_unpack() override
+		{
+			if (game::environment::is_sp()) return;
+
+			utils::hook::nop(0x1404F0D13, 4); // let our stub handle zero-source sets
+			utils::hook::jump(0x1404F0D1A, dvar_flag_checks_stub, true); // check extra dvar flags when setting values
+			
+			scheduler::once([]()
+			{
+				game::Dvar_RegisterBool("sv_cheats", false, game::DvarFlags::DVAR_FLAG_REPLICATED, "Allow cheat commands and dvars on this server");
+			});
+		}
+	};
+}
+
+REGISTER_MODULE(dvar_cheats::module)

--- a/src/client/module/dvar_cheats.cpp
+++ b/src/client/module/dvar_cheats.cpp
@@ -119,7 +119,7 @@ namespace dvar_cheats
 			scheduler::once([]()
 			{
 				game::Dvar_RegisterBool("sv_cheats", false, game::DvarFlags::DVAR_FLAG_REPLICATED, "Allow cheat commands and dvars on this server");
-			});
+			}, scheduler::pipeline::main);
 		}
 	};
 }

--- a/src/client/module/gameplay.cpp
+++ b/src/client/module/gameplay.cpp
@@ -102,7 +102,8 @@ namespace gameplay
 
 			utils::hook::jump(
 				SELECT_VALUE(0x14046EC5C, 0x140228FFF), SELECT_VALUE(pm_bouncing_stub_sp, pm_bouncing_stub_mp), true);
-			dvars::pm_bouncing = game::Dvar_RegisterBool("pm_bouncing", false, 0x1, "Enable bouncing");
+			dvars::pm_bouncing = game::Dvar_RegisterBool("pm_bouncing", false, 
+				game::DvarFlags::DVAR_FLAG_SAVED | game::DvarFlags::DVAR_FLAG_REPLICATED, "Enable bouncing");
 
 			if (game::environment::is_sp()) return;
 

--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -132,10 +132,6 @@ namespace patches
 			game::Dvar_RegisterInt("r_colorMap", 1, 1, 1, 0, "Replace all color maps with pure black or pure white");
 			game::Dvar_RegisterInt("r_lightMap", 1, 1, 1, 0, "Replace all lightmaps with pure black or pure white");
 
-			// Keeping it so it cant be used for uav cheats for people
-			game::Dvar_RegisterInt("bg_compassShowEnemies", 0, 0, 0, 0x8C,
-			                       "Whether enemies are visible on the compass at all times");
-
 			// set it to 3 to display both voice dlc announcers did only show 1
 			game::Dvar_RegisterInt("igs_announcer", 3, 3, 3, 0x0,
 			                       "Show Announcer Packs. (Bitfield representing which announcer paks to show)");


### PR DESCRIPTION
Added in sv_cheats and dvar cheat/replicated protections. Basically sv_cheats is now a replicated dvar so whenever someone joins a game, their sv_cheats is updated to match the server. If sv_cheats is changed to false, all cheat-protected dvars are reset. Only the server (or host of private match) has the ability to change dvars with the replicated flag set externally (i.e with console/cfg/etc). This prevents someone from joining a game and then changing sv_cheats or any other important replicated dvars the server sets. 

Right now sv_cheats is required to be 1 on dedis or private match to change cheat-protected dvars. I think it might make sense to always allow the server host to change any dvar even without allow sv_cheats as a whole but that can be up for discussion. This way if a server owner wants to change a dvar like bg_compassShowEnemies to 1 for UAV always on they can do so without having to completely allow all cheats